### PR TITLE
Add Jackson version management to address security vulnerabilities

### DIFF
--- a/online-store/pom.xml
+++ b/online-store/pom.xml
@@ -18,6 +18,21 @@
 		<java.version>17</java.version>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>tools.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>3.1.0</version>  <!-- Jackson 3.x -->
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>2.21.1</version>  <!-- Jackson 2.x -->
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
### Description

This pull request introduces version management for Jackson dependencies, covering both 2.x and 3.x versions. It also addresses the identified security vulnerabilities GHSA-72hv-8253-57qq and CVE-2025-52999.  

### Checklist

- [ ] Unit tests added/updated, if applicable  
- [ ] Documentation updated, if needed  
- [x] All checks pass  
- [ ] Approved by at least one reviewer